### PR TITLE
Add multidecoder output as suplimentary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ USER root
 
 RUN apt-get update && apt-get install -y libyaml-dev && rm -rf /var/lib/apt/lists/*
 
-RUN pip install utils pefile python-magic beautifulsoup4 lxml  && rm -rf ~/.cache/pip
+RUN pip install utils pefile python-magic beautifulsoup4 lxml multidecoder && rm -rf ~/.cache/pip
 
 # Switch to assemblyline user
 USER assemblyline


### PR DESCRIPTION
This will allow comparing our current frankenstrings output to multidecoder's capabilities without downloading the file and running multidecoder separately