### PR TITLE
Removing redundant start method

### DIFF
--- a/frankenstrings/frankenstrings.py
+++ b/frankenstrings/frankenstrings.py
@@ -62,9 +62,6 @@ class FrankenStrings(ServiceBase):
         self.sample_type = ''
         self.excess_extracted = 0
 
-    def start(self) -> None:
-        self.log.debug("FrankenStrings service started")
-
 # --- Support Functions ------------------------------------------------------------------------------------------------
 
     def extract_file(self, request, data, file_name, description):


### PR DESCRIPTION
The log is redundant with the one in ServiceBase.start_service