### PR TITLE
Use request.task.file_size

### DIFF
--- a/frankenstrings/frankenstrings.py
+++ b/frankenstrings/frankenstrings.py
@@ -866,7 +866,7 @@ class FrankenStrings(ServiceBase):
             bb_max_size = 200000
 
         # Begin analysis
-        if (len(request.file_contents) or 0) >= max_size or self.sample_type.startswith("archive/"):
+        if (request.task.file_size or 0) >= max_size or self.sample_type.startswith("archive/"):
             # No analysis is done if the file is an archive or too large
             return
 


### PR DESCRIPTION
That's a very small improvement, but using `request.file_contents` and reading the whole file to simply get the size is not needed. Since the file_contents is not cached, and you are doing it on line 874, you could also move line 874 before use it, or use the size that is already computed by the core.