### PR TITLE
Filter octet-stream files and check for zlib compression

### DIFF
--- a/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52/result.json
+++ b/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52/result.json
@@ -183,10 +183,6 @@
       {
         "name": "781195a9a7_embed_pe",
         "sha256": "781195a9a77fc65815532ff9caaca43a616b9152ce6e44e4bce0724ca6dc5c87"
-      },
-      {
-        "name": "all_b64_addf4b3.txt",
-        "sha256": "addf4b33cad1dd508078ebd3783de29f4134da14806a8c5c793f727482d1ada6"
       }
     ],
     "supplementary": []

--- a/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52_md_json/result.json
+++ b/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52_md_json/result.json
@@ -188,7 +188,7 @@
     "supplementary": [
       {
         "name": "30cae279_md.json",
-        "sha256": "83ce3f01f3b82b7a63bcdaa00e34a5712f7deead6cd7847735db3a4c36099c48"
+        "sha256": "1854eddcaf212d7a9bbb9133fad7273d3a821fdf9b760977c6af76848d53a8aa"
       }
     ]
   },

--- a/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52_md_json/result.json
+++ b/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52_md_json/result.json
@@ -183,10 +183,6 @@
       {
         "name": "781195a9a7_embed_pe",
         "sha256": "781195a9a77fc65815532ff9caaca43a616b9152ce6e44e4bce0724ca6dc5c87"
-      },
-      {
-        "name": "all_b64_addf4b3.txt",
-        "sha256": "addf4b33cad1dd508078ebd3783de29f4134da14806a8c5c793f727482d1ada6"
       }
     ],
     "supplementary": [

--- a/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52_md_json/result.json
+++ b/tests/results/30cae27927f4d3d7056e1a47a4a8b7229ef91f95553a9e5111570cdf147c2e52_md_json/result.json
@@ -192,7 +192,7 @@
     "supplementary": [
       {
         "name": "30cae279_md.json",
-        "sha256": "1854eddcaf212d7a9bbb9133fad7273d3a821fdf9b760977c6af76848d53a8aa"
+        "sha256": "83ce3f01f3b82b7a63bcdaa00e34a5712f7deead6cd7847735db3a4c36099c48"
       }
     ]
   },

--- a/tests/results/5742a51d02849b29289c4e454c7c3560a4acfaf916f0916457f87683011dc2fc/result.json
+++ b/tests/results/5742a51d02849b29289c4e454c7c3560a4acfaf916f0916457f87683011dc2fc/result.json
@@ -94,10 +94,6 @@
   "files": {
     "extracted": [
       {
-        "name": "all_b64_01ba471.txt",
-        "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
-      },
-      {
         "name": "559d5ca234_b64_decoded_exe",
         "sha256": "559d5ca234a68bac5a9b1130f9ec73512c1a20178daf0ce04154cbe83dcd32fe"
       },


### PR DESCRIPTION
- When extracting files use magic to check for unidentified raw data (octet-stream)
- Check if raw data is zlib-compressed and extract decompressed data
- Avoid extracting unidentifiable raw data.