### PR TITLE
Strip &#xD; and &#13; from base64

### DIFF
--- a/frankenstrings/frankenstrings.py
+++ b/frankenstrings/frankenstrings.py
@@ -36,7 +36,7 @@ PDF_HEADER = b"%PDF-"
 # PE Strings
 PAT_EXEDOS = rb"(?s)This program cannot be run in DOS mode"
 PAT_EXEHEADER = rb"(?s)MZ.{32,1024}PE\000\000.+"
-BASE64_RE = rb"={0,2}(?:[A-Za-z0-9+/]{10,}(?:&#(?:xA|10);)?[\r]?[\n]?){2,}[A-Za-z0-9+/]{2,}={0,2}"
+BASE64_RE = rb"={0,2}(?:[A-Za-z0-9+/]{10,}(?:&#(?:x[AD]|1[03]);)?[\r]?[\n]?){2,}[A-Za-z0-9+/]{2,}={0,2}"
 
 
 def extract_pdf_content(file_contents: bytes) -> bytes:
@@ -590,6 +590,8 @@ class FrankenStrings(ServiceBase):
                 .replace(b" ", b"")
                 .replace(b"&#xA;", b"")
                 .replace(b"&#10;", b"")
+                .replace(b"&#xD;", b"")
+                .replace(b"&#13;", b"")
             )
             if b64_string in b64_matches:
                 continue
@@ -615,6 +617,8 @@ class FrankenStrings(ServiceBase):
                     .replace(b" ", b"")
                     .replace(b"&#xA;", b"")
                     .replace(b"&#10;", b"")
+                    .replace(b"&#xD;", b"")
+                    .replace(b"&#13;", b"")
                 )
                 if b64_string in b64_matches:
                     continue


### PR DESCRIPTION
They are sometimes used as separators for base64 inside of xml